### PR TITLE
Configuration support and common logging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+coverage

--- a/tonic/routes.go
+++ b/tonic/routes.go
@@ -2,7 +2,6 @@ package tonic
 
 import (
 	"html/template"
-	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -142,7 +141,7 @@ func (srv *Tonic) renderForm(w http.ResponseWriter, r *http.Request, sess *db.Se
 	data["elements"] = elements
 
 	if err := tmpl.Execute(w, data); err != nil {
-		log.Printf("Failed to render form: %v", err)
+		srv.log.Printf("Failed to render form: %v", err)
 	}
 }
 
@@ -196,7 +195,7 @@ func (srv *Tonic) showJob(w http.ResponseWriter, r *http.Request, sess *db.Sessi
 	data["readonly"] = true
 
 	if err := tmpl.Execute(w, data); err != nil {
-		log.Printf("Failed to render form: %v", err)
+		srv.log.Printf("Failed to render form: %v", err)
 	}
 }
 func (srv *Tonic) renderLog(w http.ResponseWriter, r *http.Request, sess *db.Session) {
@@ -226,7 +225,7 @@ func (srv *Tonic) renderLog(w http.ResponseWriter, r *http.Request, sess *db.Ses
 		return
 	}
 	if err := tmpl.Execute(w, joblog); err != nil {
-		log.Printf("Failed to render log: %v", err)
+		srv.log.Printf("Failed to render log: %v", err)
 		srv.web.ErrorResponse(w, http.StatusInternalServerError, "Error showing job listing")
 		return
 	}
@@ -235,7 +234,7 @@ func (srv *Tonic) renderLog(w http.ResponseWriter, r *http.Request, sess *db.Ses
 func (srv *Tonic) processForm(w http.ResponseWriter, r *http.Request, sess *db.Session) {
 	err := r.ParseForm()
 	if err != nil {
-		log.Printf("Failed to parse form: %v", err)
+		srv.log.Printf("Failed to parse form: %v", err)
 	}
 	postValues := r.PostForm
 	jobValues := make(map[string]string)

--- a/tonic/routes.go
+++ b/tonic/routes.go
@@ -22,7 +22,7 @@ type authedHandler func(w http.ResponseWriter, r *http.Request, session *db.Sess
 // Use for pages that require authentication (currently, everything except the login page).
 func (srv *Tonic) reqLoginHandler(handler authedHandler) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		cookie, err := r.Cookie(srv.Config.CookieName)
+		cookie, err := r.Cookie(srv.config.CookieName)
 		if err != nil || cookie.Value == "" {
 			http.Redirect(w, r, "/login", http.StatusFound)
 			return
@@ -83,7 +83,7 @@ func (srv *Tonic) userLoginPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := gogs.NewClient(srv.Config.GINServer, "")
+	client := gogs.NewClient(srv.config.GINServer, "")
 	var userToken string
 	tokens, err := client.ListAccessTokens(username, password)
 	if err != nil {
@@ -105,7 +105,7 @@ func (srv *Tonic) userLoginPost(w http.ResponseWriter, r *http.Request) {
 	sess := db.NewSession(userToken)
 
 	cookie := http.Cookie{
-		Name:    srv.Config.CookieName,
+		Name:    srv.config.CookieName,
 		Value:   sess.ID,
 		Expires: time.Now().Add(7 * 24 * time.Hour), // TODO: Configurable expiration
 		Secure:  false,
@@ -212,7 +212,7 @@ func (srv *Tonic) renderLog(w http.ResponseWriter, r *http.Request, sess *db.Ses
 		return
 	}
 
-	cl := worker.NewClient(srv.Config.GINServer, sess.Token)
+	cl := worker.NewClient(srv.config.GINServer, sess.Token)
 	user, err := cl.GetSelfInfo()
 	if err != nil {
 		// TODO: Check for error type (unauthorized?)
@@ -244,7 +244,7 @@ func (srv *Tonic) processForm(w http.ResponseWriter, r *http.Request, sess *db.S
 		jobValues[key] = postValues.Get(key)
 	}
 
-	client := worker.NewClient(srv.Config.GINServer, sess.Token)
+	client := worker.NewClient(srv.config.GINServer, sess.Token)
 	srv.worker.Enqueue(worker.NewUserJob(client, jobValues))
 
 	// redirect to job log

--- a/tonic/service.go
+++ b/tonic/service.go
@@ -30,13 +30,13 @@ type Tonic struct {
 	worker *worker.Worker
 	log    *log.Logger // TODO: Move all log messages to this logger
 	form   []Element
-	Config *Config
+	config *Config
 }
 
 // NewService creates a new Tonic with a given form and custom job action.
 func NewService(form []Element, f worker.JobAction, config Config) (*Tonic, error) {
 	srv := new(Tonic)
-	srv.Config = &config
+	srv.config = &config
 	// DB
 	log.Print("Initialising database")
 	conn, err := db.New(config.DBPath)
@@ -64,10 +64,10 @@ func NewService(form []Element, f worker.JobAction, config Config) (*Tonic, erro
 // login to configured GIN server as the bot user that represents this service
 // and attach a new authenticated gogs.Client to the service struct.
 func (srv *Tonic) login() error {
-	username := srv.Config.GINUsername
-	password := srv.Config.GINPassword
+	username := srv.config.GINUsername
+	password := srv.config.GINPassword
 
-	client := gogs.NewClient(srv.Config.GINServer, "")
+	client := gogs.NewClient(srv.config.GINServer, "")
 	tokens, err := client.ListAccessTokens(username, password)
 	if err != nil {
 		return err
@@ -82,7 +82,7 @@ func (srv *Tonic) login() error {
 			return err
 		}
 	}
-	srv.worker.SetClient(worker.NewClient(srv.Config.GINServer, token.Sha1))
+	srv.worker.SetClient(worker.NewClient(srv.config.GINServer, token.Sha1))
 	return nil
 }
 
@@ -103,7 +103,7 @@ func (srv *Tonic) Start() error {
 	srv.web.Start()
 	log.Print("Web server started")
 
-	if srv.Config.GINServer != "" {
+	if srv.config.GINServer != "" {
 		log.Print("Logging in to gin")
 		if err := srv.login(); err != nil {
 			return err

--- a/tonic/service.go
+++ b/tonic/service.go
@@ -20,6 +20,7 @@ type Config struct {
 	Port        uint16
 	CookieName  string
 	DBPath      string
+	GINUsername string
 	GINPassword string
 }
 
@@ -35,12 +36,12 @@ type Tonic struct {
 }
 
 // NewService creates a new Tonic with a given form and custom job action.
-func NewService(form []Element, f worker.JobAction) (*Tonic, error) {
+func NewService(form []Element, f worker.JobAction, config Config) (*Tonic, error) {
 	srv := new(Tonic)
+	srv.Config = &config
 	// DB
-	// TODO: Define db path in config
 	log.Print("Initialising database")
-	conn, err := db.New("./test.db")
+	conn, err := db.New(config.DBPath)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +52,7 @@ func NewService(form []Element, f worker.JobAction) (*Tonic, error) {
 	srv.worker = worker.New(srv.db)
 
 	// Web server
-	srv.web = web.New()
+	srv.web = web.New(config.Port)
 	srv.setupWebRoutes()
 
 	// set form and func

--- a/tonic/tonic_test.go
+++ b/tonic/tonic_test.go
@@ -6,17 +6,17 @@ import (
 )
 
 func TestTonicFailStart(t *testing.T) {
-	if s, _ := NewService(nil, nil); s.Start() == nil {
+	if s, _ := NewService(nil, nil, Config{}); s.Start() == nil {
 		s.Stop()
 		t.Fatal("Service start succeeded; should have failed")
 	}
 
-	if s, _ := NewService(make([]Element, 0), nil); s.Start() == nil {
+	if s, _ := NewService(make([]Element, 0), nil, Config{}); s.Start() == nil {
 		s.Stop()
 		t.Fatal("Service start succeeded; should have failed")
 	}
 
-	if s, _ := NewService(make([]Element, 10), nil); s.Start() == nil {
+	if s, _ := NewService(make([]Element, 10), nil, Config{}); s.Start() == nil {
 		s.Stop()
 		t.Fatal("Service start succeeded; should have failed")
 	}
@@ -37,7 +37,7 @@ func TestTonicFull(t *testing.T) {
 			Description: "Field of tests, part 2",
 		},
 	}
-	srv, err := NewService(f, testAction)
+	srv, err := NewService(f, testAction, Config{})
 	if err != nil {
 		t.Fatalf("Failed to initialise tonic service: %s", err.Error())
 	}

--- a/tonic/web/web.go
+++ b/tonic/web/web.go
@@ -3,15 +3,17 @@ package web
 import (
 	"context"
 	"encoding/json"
-	"github.com/G-Node/tonic/templates"
-	"github.com/gogs/go-gogs-client"
-	"github.com/gorilla/mux"
+	"fmt"
 	"html/template"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/G-Node/tonic/templates"
+	"github.com/gogs/go-gogs-client"
+	"github.com/gorilla/mux"
 )
 
 // TODO: Set in config
@@ -88,14 +90,13 @@ type Server struct {
 }
 
 // New returns a web Server with an initialised mux.Router and http.Server.
-func New() *Server {
+func New(port uint16) *Server {
 	srv := new(Server)
 	srv.Router = new(mux.Router)
 	httpsrv := new(http.Server)
 	httpsrv.Handler = srv.Router
 
-	// TODO: read port from config
-	httpsrv.Addr = ":3000"
+	httpsrv.Addr = fmt.Sprintf(":%d", port)
 	// Good practice to set timeouts to avoid Slowloris attacks.
 	httpsrv.WriteTimeout = time.Second * 15
 	httpsrv.ReadTimeout = time.Second * 15

--- a/tonic/web/web.go
+++ b/tonic/web/web.go
@@ -2,57 +2,15 @@ package web
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/G-Node/tonic/templates"
-	"github.com/gogs/go-gogs-client"
 	"github.com/gorilla/mux"
 )
-
-// TODO: Set in config
-const ginserver = "https://gin.dev.g-node.org"
-
-func login() string {
-	// TODO: Set password in config
-	passfile, err := os.Open("testbot")
-	if err != nil {
-		return ""
-	}
-
-	passdata, err := ioutil.ReadAll(passfile)
-	if err != nil {
-		return ""
-	}
-
-	userpass := make(map[string]string)
-
-	err = json.Unmarshal(passdata, &userpass)
-	if err != nil {
-		return ""
-	}
-
-	client := gogs.NewClient(ginserver, "")
-	tokens, err := client.ListAccessTokens(userpass["username"], userpass["password"])
-	if err != nil {
-		return ""
-	}
-
-	if len(tokens) > 0 {
-		return tokens[0].Sha1
-	}
-	token, err := client.CreateAccessToken(userpass["username"], userpass["password"], gogs.CreateAccessTokenOption{Name: "testbot"})
-	if err != nil {
-		return ""
-	}
-	return token.Sha1
-}
 
 // ErrorResponse logs an error and renders an error page with the given message,
 // returning the given status code to the user.

--- a/utonics/example/main.go
+++ b/utonics/example/main.go
@@ -11,7 +11,6 @@ import (
 )
 
 func main() {
-
 	elems := []tonic.Element{
 		{
 			Name:  "name",
@@ -27,11 +26,18 @@ func main() {
 			Description: "Seconds to wait before finishing the job.  Use for simulating long-running jobs.",
 		},
 	}
-	ut, err := tonic.NewService(elems, exampleFunc)
+	config := tonic.Config{
+		GINServer:   "", // not used in example
+		GINUsername: "", // not used in example
+		GINPassword: "", // not used in example
+		CookieName:  "utonic-example",
+		Port:        3000,
+		DBPath:      "./example.db",
+	}
+	ut, err := tonic.NewService(elems, exampleFunc, config)
 	if err != nil {
 		log.Fatal(err)
 	}
-	ut.Config = &tonic.Config{GINServer: "https://gin.dev.g-node.org", CookieName: "utonic-example"}
 	ut.Start()
 	defer ut.Stop()
 	ut.WaitForInterrupt()

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -31,11 +31,18 @@ func main() {
 			Required:    false,
 		},
 	}
-	tsrv, err := tonic.NewService(form, newProject)
+	config := tonic.Config{
+		GINServer:   "https://gin.dev.g-node.org",
+		GINUsername: "", // TODO: Load from file
+		GINPassword: "", // TODO: Load from file
+		CookieName:  "utonic-labproject",
+		Port:        3000,
+		DBPath:      "./labproject.db",
+	}
+	tsrv, err := tonic.NewService(form, newProject, config)
 	if err != nil {
 		log.Fatal(err)
 	}
-	tsrv.Config = &tonic.Config{GINServer: "https://gin.dev.g-node.org", CookieName: "utonic-labproject"}
 	tsrv.Start()
 	tsrv.WaitForInterrupt()
 	tsrv.Stop()

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/G-Node/tonic/tonic"
 	"github.com/G-Node/tonic/tonic/worker"
 	"github.com/gogs/go-gogs-client"
+	"io/ioutil"
 	"log"
+	"os"
 )
 
 func main() {
@@ -31,10 +34,11 @@ func main() {
 			Required:    false,
 		},
 	}
+	username, password := readPassfile("testbot")
 	config := tonic.Config{
 		GINServer:   "https://gin.dev.g-node.org",
-		GINUsername: "", // TODO: Load from file
-		GINPassword: "", // TODO: Load from file
+		GINUsername: username,
+		GINPassword: password,
 		CookieName:  "utonic-labproject",
 		Port:        3000,
 		DBPath:      "./labproject.db",
@@ -156,4 +160,21 @@ func getAvailableOrgs(botClient, userClient *worker.Client) ([]gogs.Organization
 	}
 
 	return validOrgs, nil
+}
+
+func readPassfile(filename string) (string, string) {
+	passfile, err := os.Open(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	passdata, err := ioutil.ReadAll(passfile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	userpass := make(map[string]string)
+	if err := json.Unmarshal(passdata, &userpass); err != nil {
+		log.Fatal(err)
+	}
+	return userpass["username"], userpass["password"]
 }


### PR DESCRIPTION
This PR makes the configuration values for each service mandatory.  A concrete instance of `tonic.Config` is required when initialising a new service through the `tonic.New()` function.  Reading configuration values either from a file or from env vars (or however else) is the responsibility of each service using the library.

Closes #7.

The PR also sets a logger member for each service struct (tonic service, worker queue, and web service).  Each `New()` function defines its own logger when creating the service.  This can be replaced using the `SetLogger()` function.  When creating a tonic service or replacing its logger, it shares its logger with both the worker queue and the web service.