### PR TITLE
Form enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 coverage
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SOURCES = $(shell find . -type f -iname "*.go") go.mod go.sum
 
-.PHONY: clean test showcoverage
+.PHONY: clean test
 
 all: utonics
 
@@ -11,8 +11,10 @@ utonics: $(SOURCES)
 test: $(SOURCES)
 	go test -race -coverpkg=./... -coverprofile=coverage ./...
 
-showcoverage: test
-	go tool cover -html=coverage
+coverage: test
+
+coverage.html: coverage
+	go tool cover -html=coverage -o coverage.html
 
 clean:
 	rm -rf coverage build/

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@
 
 
 Tonic is a framework for building services that interact with the [GIN](https://gin.g-node.org) API.
+
+## Building examples
+
+The project currently includes two built-in services as examples.
+See the [relevant docs](./docs/README.md) for a description of each one and instructions on how to build and use them.

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -413,14 +413,17 @@ textarea#description {
   font-size: 1rem;
   vertical-align: middle;
 }
+.ginform {
+  padding-bottom: 150px;
+}
 .ginform form {
   margin: auto;
   width: 800px!important;
 }
-.ginform form .ui.message,
+.ginform form .ui.message {
   text-align: center;
 }
-.ginform form .header, {
+.ginform form .header {
   padding-left: 280px !important;
 }
 .ginform form .inline.field > label {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "utonics"  # ignore built-in microservices

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ The PostAction function takes three arguments:
 
 The PostAction should use the bot client to perform actions for the using the bot client and return a list of messages.  The messages should serve as an action log for users to review or to troubleshoot any problems.  The following is a non-exhaustive list of examples of some actions that the PostAction could perform for a user:
 - Create a repository in an organisation in which the user is not an owner (see the [lab project](./labproject.md) microservice).
-- Invite another user to a team in an organisation in which the user it not an owner.
+- Invite another user to a team in an organisation in which the user is not an owner.
 - Rename or otherwise modify a repository of which they're not an admin.
 
 The purpose of services like these is to give users the ability to perform specific administrative-level actions without giving them full administrative rights.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,59 @@
+# Developer documentation
+
+## Example services
+
+Currently the project includes two example services.
+- The [Example](./example.md) service is meant to be a simple example that demonstrates how to write a service using the framework.  The core functionality doesn't perform any useful actions, but it should serve as a good starting point.
+- the [Lab project](./labproject.md) service is a more useful, real world service.  It's the service that the framework was originally built to serve and so informed a lot of the design decisions of the early stages of the project.
+
+
+## Writing a service
+
+Each service must be initialised with at least three arguments:
+- A form instance.
+- A PreAction function or a PostAction function (or both).
+- A configuration instance.
+
+### Forms
+
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/g-node/tonic)](https://pkg.go.dev/github.com/G-Node/tonic/tonic/form#Form)
+
+A Form consists of one or more Pages.
+A Page consists of one or more Elements.
+Each Element defines an HTML form input of a given type.
+
+Tonic uses this Form definition to create a web form with the given elements.  The form is displayed on a single page, but the different pages define separate sections of the form.
+
+### PreAction and PostAction functions
+
+The Action functions serve to process information on behalf of the user.
+The [PreAction](#preaction) is meant to process information before the Form is displayed (e.g., to specify allowed values or valid elements).
+The [PostAction](#postaction) is meant to process the data submitted by the user through the Form.
+
+#### PreAction
+
+The PreAction function takes three arguments:
+1. A copy of the Form instance defined for the service.
+2. A Client representing the service itself (bot client).
+3. A Client representing the user that's logged in (user client).
+
+The PreAction should use the bot and user clients to determine if any modifications to the form are necessary and return a new instance of the Form with any modifications made.  The following is a non-exhaustive list of examples of some modifications that the PreAction could make to the Form:
+- Set a list of values for a Select type element based on the options relevant to the user.
+- Disable an element that the specific user shouldn't have access to.
+- Fill in the value of an element and mark it _read only_ if it only has one valid value.
+
+In the case of services that don't define a PostAction, the PreAction can be used to build information-only services, that is, services that simply display information to a user but don't take any input.
+
+#### PostAction
+
+The PostAction function takes three arguments:
+1. A map of values (`string->string`) that represent the values the user entered into the form.
+2. A Client representing the service itself (bot client).
+3. A client representing the user that's logged in (user client).
+
+The PostAction should use the bot client to perform actions for the using the bot client and return a list of messages.  The messages should serve as an action log for users to review or to troubleshoot any problems.  The following is a non-exhaustive list of examples of some actions that the PostAction could perform for a user:
+- Create a repository in an organisation in which the user is not an owner (see the [lab project](./labproject.md) microservice).
+- Invite another user to a team in an organisation in which the user it not an owner.
+- Rename or otherwise modify a repository of which they're not an admin.
+
+The purpose of services like these is to give users the ability to perform specific administrative-level actions without giving them full administrative rights.

--- a/docs/example.md
+++ b/docs/example.md
@@ -5,10 +5,12 @@ It defines the following service components:
 
 ## Form
 
-The Form consists of a single page with 3 elements:
+The Form consists of two pages.  The first page contains 3 elements:
 1. Name: a simple text field.
 2. Descritpion: a long form text area.
 3. Duration: the duration in seconds that the action will run for.
+
+A second page includes one of each type of input supported for demonstration purposes.
 
 ## PostAction
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -1,0 +1,20 @@
+# Example service
+
+The [example](/utonics/example/main.go) service implements a very simple service that serves no useful purpose, but demonstrates how a service can be built.
+It defines the following service components:
+
+## Form
+
+The Form consists of a single page with 3 elements:
+1. Name: a simple text field.
+2. Descritpion: a long form text area.
+3. Duration: the duration in seconds that the action will run for.
+
+## PostAction
+
+The PostAction of the service simply waits for the defined duration specified by the form and then returns a message log of the values it received.
+
+## Config
+
+The configuration does not specify a GIN server to connect to (or credentials) since it doesn't perform any online tasks.
+The path to the database, a port number for the service, and a cookie name for the user's session are all required.

--- a/docs/labproject.md
+++ b/docs/labproject.md
@@ -1,0 +1,39 @@
+# Lab project service
+
+The [lab project](/utonics/labproject/main.go) service takes advantage of almost all the features of Tonic.  Its purpose is to create repositories inside an organisation on GIN where the user is not an administrator or owner.
+It defines the following service components:
+
+## Form
+
+The Form consists of a two pages.
+
+The first page consists of three elements:
+1. Lab organisation: The name of the organisation in which the repository is going to be created.
+2. Project name: The name of the repository or repositories to be created.
+3. Description: A long description for the project.
+
+The second page includes toggles for submodules that the user may or may not require for the project.
+
+## PreAction
+
+The PreAction determines whether there are any organisations on GIN in which the user is allowed to create repositories.  The requirements for an organisation to be eligible are:
+- The service bot must be an owner or administrator of the organisation.
+- The user must be a member of the organisation.
+
+Since multiple organisations may fit the requirements, the PreAction determines their names and sets the available values for the _Lab organisation_ select field.
+
+## PostAction
+
+The PostAction receives the form values and creates the repository on behalf of the user.  Before doing so, it checks if the organisation is in fact eligible using the same criteria defined in the [PreAction](#preaction).
+
+If the input is valid, the service performs the following actions:
+- Create a **repository** with the _Project name_ as defined by the user.
+- Create a **team** with the _Project name_ as defined by the user.
+- Adds the service user to the **team**.
+- Adds the **repository** to the **team**.
+
+*Note: More actions are planned for this service and will be added soon.*
+
+## Config
+
+The configuration specifies the GIN server to connect to (currently gin.dev.g-node.org for testing purposes).  The username and password are for the bot user that the service uses to perform actions.  These credentials should be provided through a json file called `testbot`.

--- a/docs/labproject.md
+++ b/docs/labproject.md
@@ -9,8 +9,9 @@ The Form consists of two pages.
 
 The first page consists of three elements:
 1. Lab organisation: The name of the organisation in which the repository is going to be created.
-2. Project name: The name of the repository or repositories to be created.
-3. Description: A long description for the project.
+2. Optionally a team name where the repository will be added. If none is indicated, a team with the same name as the repository will be created.
+3. Project name: The name of the repository or repositories to be created.
+4. Description: A long description for the project.
 
 The second page includes toggles for submodules that the user may or may not require for the project.
 

--- a/docs/labproject.md
+++ b/docs/labproject.md
@@ -5,7 +5,7 @@ It defines the following service components:
 
 ## Form
 
-The Form consists of a two pages.
+The Form consists of two pages.
 
 The first page consists of three elements:
 1. Lab organisation: The name of the organisation in which the repository is going to be created.

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/mattn/go-sqlite3 v1.14.0
+	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	xorm.io/xorm v1.0.3
 )

--- a/templates/form.go
+++ b/templates/form.go
@@ -18,7 +18,7 @@ const Form = `
 									{{range $elem := $page.Elements}}
 										<div class="inline {{if $elem.Required}}required{{end}} field ">
 											<label for="{{$elem.ID}}">{{$elem.Label}}</label>
-											<input id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if or $elem.ReadOnly $.readonly}}readonly{{end}}>
+											<input type="{{$elem.Type}}" id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if or $elem.ReadOnly $.readonly}}readonly{{end}}>
 											<span class="help">{{$elem.Description}}</span>
 										</div>
 									{{end}}

--- a/templates/form.go
+++ b/templates/form.go
@@ -18,7 +18,18 @@ const Form = `
 									{{range $elem := $page.Elements}}
 										<div class="inline {{if $elem.Required}}required{{end}} field ">
 											<label for="{{$elem.ID}}">{{$elem.Label}}</label>
-											<input type="{{$elem.Type}}" id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if or $elem.ReadOnly $.readonly}}readonly{{end}}>
+											{{if eq $elem.Type "textarea"}}
+												<textarea id="{{$elem.ID}}" name="{{$elem.Name}}" {{if $elem.Required}}required{{end}} {{if or $elem.ReadOnly $.readonly}}readonly{{end}}>{{$elem.Value}}</textarea>
+											{{else}}
+												<input type="{{$elem.Type}}" id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if or $elem.ReadOnly $.readonly}}readonly{{end}} {{if $elem.ValueList}}list="{{$elem.ID}}-values"{{end}}>
+												{{if $elem.ValueList}}
+												<datalist id="{{$elem.ID}}-values">
+													{{range $value := $elem.ValueList}}
+													<option value="{{$value}}">
+													{{end}}
+												</datalist>
+												{{end}}
+											{{end}}
 											<span class="help">{{$elem.Description}}</span>
 										</div>
 									{{end}}

--- a/templates/form.go
+++ b/templates/form.go
@@ -20,6 +20,12 @@ const Form = `
 											<label for="{{$elem.ID}}">{{$elem.Label}}</label>
 											{{if eq $elem.Type "textarea"}}
 												<textarea id="{{$elem.ID}}" name="{{$elem.Name}}" {{if $elem.Required}}required{{end}} {{if or $elem.ReadOnly $.readonly}}readonly{{end}}>{{$elem.Value}}</textarea>
+											{{else if eq $elem.Type "select"}}
+												<select id="{{$elem.ID}}" name="{{$elem.Name}}">
+													{{range $value := $elem.ValueList}}
+														<option value="{{$value}}">{{$value}}</option>
+													{{end}}
+												</select>
 											{{else}}
 												<input type="{{$elem.Type}}" id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if or $elem.ReadOnly $.readonly}}readonly{{end}} {{if $elem.ValueList}}list="{{$elem.ID}}-values"{{end}}>
 												{{if $elem.ValueList}}

--- a/templates/form.go
+++ b/templates/form.go
@@ -18,7 +18,7 @@ const Form = `
 									{{range $elem := $page.Elements}}
 										<div class="inline {{if $elem.Required}}required{{end}} field ">
 											<label for="{{$elem.ID}}">{{$elem.Label}}</label>
-											<input id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if $.readonly}}readonly{{end}}>
+											<input id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if or $elem.ReadOnly $.readonly}}readonly{{end}}>
 											<span class="help">{{$elem.Description}}</span>
 										</div>
 									{{end}}

--- a/templates/form.go
+++ b/templates/form.go
@@ -9,17 +9,18 @@ const Form = `
 						<form class="ui form" action="/" method="post">
 							<input type="hidden" name="_csrf" value="">
 							<h3 class="ui top attached header">
-								Demo form
+								{{.form.Name}}
 							</h3>
+							{{.form.Description}}
 							<div class="ui attached segment">
-								{{with .elements}}
-									{{range $idx, $elem := .}}
-										<div class="inline {{if $elem.Required}}required{{end}} field ">
-											<label for="{{$elem.ID}}">{{$elem.Label}}</label>
-											<input id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if $.readonly}}readonly{{end}}>
-											<span class="help">{{$elem.Description}}</span>
-										</div>
-									{{end}}
+								{{$page := index .form.Pages 0}}
+								{{$page.Description}}
+								{{range $idx, $elem := $page.Elements}}
+									<div class="inline {{if $elem.Required}}required{{end}} field ">
+										<label for="{{$elem.ID}}">{{$elem.Label}}</label>
+										<input id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if $.readonly}}readonly{{end}}>
+										<span class="help">{{$elem.Description}}</span>
+									</div>
 								{{end}}
 								{{if not .readonly}}
 									<div class="inline field">

--- a/templates/form.go
+++ b/templates/form.go
@@ -17,26 +17,7 @@ const Form = `
 									 <p>{{$page.Description}}</p> 
 									{{range $elem := $page.Elements}}
 										<div class="inline {{if $elem.Required}}required{{end}} field ">
-											<label for="{{$elem.ID}}">{{$elem.Label}}</label>
-											{{if eq $elem.Type "textarea"}}
-												<textarea id="{{$elem.ID}}" name="{{$elem.Name}}" {{if $elem.Required}}required{{end}} {{if or $elem.ReadOnly $.readonly}}readonly{{end}}>{{$elem.Value}}</textarea>
-											{{else if eq $elem.Type "select"}}
-												<select id="{{$elem.ID}}" name="{{$elem.Name}}">
-													{{range $value := $elem.ValueList}}
-														<option value="{{$value}}">{{$value}}</option>
-													{{end}}
-												</select>
-											{{else}}
-												<input type="{{$elem.Type}}" id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if or $elem.ReadOnly $.readonly}}readonly{{end}} {{if $elem.ValueList}}list="{{$elem.ID}}-values"{{end}}>
-												{{if $elem.ValueList}}
-												<datalist id="{{$elem.ID}}-values">
-													{{range $value := $elem.ValueList}}
-													<option value="{{$value}}">
-													{{end}}
-												</datalist>
-												{{end}}
-											{{end}}
-											<span class="help">{{$elem.Description}}</span>
+											{{$elem.HTML}}
 										</div>
 									{{end}}
 									<div class="ui divider"></div>

--- a/templates/form.go
+++ b/templates/form.go
@@ -13,14 +13,16 @@ const Form = `
 							</h3>
 							{{.form.Description}}
 							<div class="ui attached segment">
-								{{$page := index .form.Pages 0}}
-								{{$page.Description}}
-								{{range $idx, $elem := $page.Elements}}
-									<div class="inline {{if $elem.Required}}required{{end}} field ">
-										<label for="{{$elem.ID}}">{{$elem.Label}}</label>
-										<input id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if $.readonly}}readonly{{end}}>
-										<span class="help">{{$elem.Description}}</span>
-									</div>
+								{{range $page := .form.Pages}}
+									 <p>{{$page.Description}}</p> 
+									{{range $elem := $page.Elements}}
+										<div class="inline {{if $elem.Required}}required{{end}} field ">
+											<label for="{{$elem.ID}}">{{$elem.Label}}</label>
+											<input id="{{$elem.ID}}" name="{{$elem.Name}}" value="{{$elem.Value}}" autofocus {{if $elem.Required}}required{{end}} {{if $.readonly}}readonly{{end}}>
+											<span class="help">{{$elem.Description}}</span>
+										</div>
+									{{end}}
+									<div class="ui divider"></div>
 								{{end}}
 								{{if not .readonly}}
 									<div class="inline field">

--- a/tonic/form/form_test.go
+++ b/tonic/form/form_test.go
@@ -1,0 +1,66 @@
+package form
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"testing"
+
+	"github.com/G-Node/tonic/templates"
+	"golang.org/x/net/html"
+)
+
+var allElementTypes = []ElementType{CheckboxInput, ColorInput, DateInput, DateTimeInput, EmailInput, FileInput, HiddenInput, MonthInput, NumberInput, PasswordInput, RadioInput, RangeInput, SearchInput, TelInput, TextInput, TimeInput, URLInput, WeekInput, TextArea, Select}
+
+func TestFormElementsHTML(t *testing.T) {
+	testElements := make([]Element, len(allElementTypes))
+	for idx := range allElementTypes {
+		elemType := allElementTypes[idx]
+		elem := Element{
+			ID:          fmt.Sprintf("id%s", elemType),
+			Name:        string(elemType),
+			Label:       fmt.Sprintf("Element type %s", elemType),
+			Description: fmt.Sprintf("An element of type %s", elemType),
+			ValueList: []string{ // will only have effect on the types where it's valid
+				fmt.Sprintf("%s option one", elemType),
+				fmt.Sprintf("%s option two", elemType),
+				fmt.Sprintf("%s option three", elemType),
+			},
+			Type: elemType,
+		}
+		testElements[idx] = elem
+	}
+
+	testPage := Page{
+		Description: "One of each element supported by Tonic",
+		Elements:    testElements,
+	}
+	testForm := Form{
+		Pages:       []Page{testPage},
+		Name:        "Tonic example form",
+		Description: "",
+	}
+
+	// render form and check if it's valid HTML
+	tmpl := template.New("layout")
+	tmpl, err := tmpl.Parse(templates.Layout)
+	if err != nil {
+		t.Fatalf("Failed to parse Layout template: %s", err.Error())
+	}
+	tmpl, err = tmpl.Parse(templates.Form)
+	if err != nil {
+		t.Fatalf("Failed to parse Form template: %s", err.Error())
+	}
+
+	data := make(map[string]interface{})
+	data["form"] = testForm
+
+	formHTML := new(bytes.Buffer)
+	if err := tmpl.Execute(formHTML, data); err != nil {
+		t.Fatalf("Failed to render form: %v", err.Error())
+	}
+
+	if _, err := html.Parse(formHTML); err != nil {
+		t.Fatalf("Bad HTML when rendering form: %v", err.Error())
+	}
+}

--- a/tonic/form/forms.go
+++ b/tonic/form/forms.go
@@ -7,26 +7,46 @@ import (
 )
 
 const (
+	// CheckboxInput is a fieldset that groups a number of "checkbox" inputs for the same variable.
 	CheckboxInput ElementType = "checkbox"
-	ColorInput    ElementType = "color"
-	DateInput     ElementType = "date"
+	// ColorInput is an input element with type "color".
+	ColorInput ElementType = "color"
+	// DateInput is an input element with type "date"."
+	DateInput ElementType = "date"
+	// DateTimeInput is an input element with type "datetime-local".
 	DateTimeInput ElementType = "datetime-local"
-	EmailInput    ElementType = "email"
-	FileInput     ElementType = "file"
-	HiddenInput   ElementType = "hidden"
-	MonthInput    ElementType = "month"
-	NumberInput   ElementType = "number"
+	// EmailInput is an input element with type "email".
+	EmailInput ElementType = "email"
+	// FileInput is an input element with type "file".
+	FileInput ElementType = "file"
+	// HiddenInput is an input element with type "hidden".
+	HiddenInput ElementType = "hidden"
+	// MonthInput is an input element with type "month".
+	MonthInput ElementType = "month"
+	// NumberInput is an input element with type "number".
+	NumberInput ElementType = "number"
+	// PasswordInput is an input element with type "password".
 	PasswordInput ElementType = "password"
-	RadioInput    ElementType = "radio"
-	RangeInput    ElementType = "range"
-	SearchInput   ElementType = "search"
-	TelInput      ElementType = "tel"
-	TextInput     ElementType = "text"
-	TimeInput     ElementType = "time"
-	URLInput      ElementType = "url"
-	WeekInput     ElementType = "week"
-	TextArea      ElementType = "textarea"
-	Select        ElementType = "select"
+	// RadioInput is a fieldset that groups a number of "radio" inputs for the same variable.
+	RadioInput ElementType = "radio"
+	// RangeInput is an input element with type "range".
+	RangeInput ElementType = "range"
+	// SearchInput is an input element with type "search".
+	SearchInput ElementType = "search"
+	// TelInput is an input element with type "tel".
+	TelInput ElementType = "tel"
+	// TextInput is an input element with type "text".
+	TextInput ElementType = "text"
+	// TimeInput is an input element with type "time".
+	TimeInput ElementType = "time"
+	// URLInput is an input element with type "url".
+	URLInput ElementType = "url"
+	// WeekInput is an input element with type "week".
+	WeekInput ElementType = "week"
+	// TextArea is an "textarea" element.
+	TextArea ElementType = "textarea"
+	// Select is an input element with type "select".  Requires a ValueList.
+	Select ElementType = "select"
 )
 
 // ElementType defines the type of a form input element:

--- a/tonic/form/forms.go
+++ b/tonic/form/forms.go
@@ -12,7 +12,6 @@ const (
 	MonthInput    ElementType = "month"
 	NumberInput   ElementType = "number"
 	PasswordInput ElementType = "password"
-	RadioInput    ElementType = "radio"
 	RangeInput    ElementType = "range"
 	SearchInput   ElementType = "search"
 	TelInput      ElementType = "tel"

--- a/tonic/form/forms.go
+++ b/tonic/form/forms.go
@@ -69,4 +69,6 @@ type Element struct {
 	// DataList should contain a set of values that represent the permissible
 	// or recommended options available to the element.
 	DataList []string
+	// Read only fields can't be edited.
+	ReadOnly bool
 }

--- a/tonic/form/forms.go
+++ b/tonic/form/forms.go
@@ -20,6 +20,8 @@ const (
 	TimeInput     ElementType = "time"
 	URLInput      ElementType = "url"
 	WeekInput     ElementType = "week"
+	TextArea      ElementType = "textarea"
+	Select        ElementType = "select"
 )
 
 // ElementType defines the type of a form input element:
@@ -66,9 +68,11 @@ type Element struct {
 	Description string
 	// Type is the HTML input element type.
 	Type ElementType
-	// DataList should contain a set of values that represent the permissible
-	// or recommended options available to the element.
-	DataList []string
+	// ValueList should contain a set of values that represent the permissible
+	// or recommended options available to the element.  For input type
+	// elements, it represents suggested values (datalist).  For select
+	// elements, it represents the values in the list.
+	ValueList []string
 	// Read only fields can't be edited.
 	ReadOnly bool
 }

--- a/tonic/form/forms.go
+++ b/tonic/form/forms.go
@@ -1,4 +1,4 @@
-package tonic
+package form
 
 const (
 	CheckboxInput ElementType = "checkbox"
@@ -22,6 +22,8 @@ const (
 	WeekInput     ElementType = "week"
 )
 
+// ElementType defines the type of a form input element:
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
 type ElementType string
 
 // Form is the top level type for defining the web form for user input.

--- a/tonic/forms.go
+++ b/tonic/forms.go
@@ -1,5 +1,29 @@
 package tonic
 
+const (
+	CheckboxInput ElementType = "checkbox"
+	ColorInput    ElementType = "color"
+	DateInput     ElementType = "date"
+	DateTimeInput ElementType = "datetime-local"
+	EmailInput    ElementType = "email"
+	FileInput     ElementType = "file"
+	HiddenInput   ElementType = "hidden"
+	ImageInput    ElementType = "image"
+	MonthInput    ElementType = "month"
+	NumberInput   ElementType = "number"
+	PasswordInput ElementType = "password"
+	RadioInput    ElementType = "radio"
+	RangeInput    ElementType = "range"
+	SearchInput   ElementType = "search"
+	TelInput      ElementType = "tel"
+	TextInput     ElementType = "text"
+	TimeInput     ElementType = "time"
+	URLInput      ElementType = "url"
+	WeekInput     ElementType = "week"
+)
+
+type ElementType string
+
 // Form is the top level type for defining the web form for user input.
 type Form struct {
 	// The Name appears at the top of all pages in the form and in the HTML
@@ -38,4 +62,9 @@ type Element struct {
 	// the input field.  Can be used to provide extra information such as input
 	// constraints.
 	Description string
+	// Type is the HTML input element type.
+	Type ElementType
+	// DataList should contain a set of values that represent the permissible
+	// or recommended options available to the element.
+	DataList []string
 }

--- a/tonic/routes.go
+++ b/tonic/routes.go
@@ -180,14 +180,15 @@ func (srv *Tonic) showJob(w http.ResponseWriter, r *http.Request, sess *db.Sessi
 
 	// Set up form and assign values to each matching element
 	data := make(map[string]interface{})
-	page := srv.form.Pages[0] // TODO: All pages
-	elements := page.Elements
-	for idx := range elements {
-		if val, ok := job.ValueMap[elements[idx].Name]; ok {
-			elements[idx].Value = val
-			// convert <select> elements to regular text <input> to show value
-			if elements[idx].Type == form.Select {
-				elements[idx].Type = form.TextInput
+	for _, page := range srv.form.Pages {
+		elements := page.Elements
+		for idx := range elements {
+			if val, ok := job.ValueMap[elements[idx].Name]; ok {
+				elements[idx].Value = val
+				// convert <select> elements to regular text <input> to show value
+				if elements[idx].Type == form.Select {
+					elements[idx].Type = form.TextInput
+				}
 			}
 		}
 	}
@@ -249,12 +250,13 @@ func (srv *Tonic) processForm(w http.ResponseWriter, r *http.Request, sess *db.S
 	}
 	postValues := r.PostForm
 	jobValues := make(map[string]string)
-	elements := srv.form.Pages[0].Elements // TODO: All pages
-	for idx := range elements {
-		key := elements[idx].Name
-		jobValues[key] = postValues.Get(key)
+	for _, page := range srv.form.Pages {
+		elements := page.Elements
+		for idx := range elements {
+			key := elements[idx].Name
+			jobValues[key] = postValues.Get(key)
+		}
 	}
-
 	client := worker.NewClient(srv.config.GINServer, sess.Token)
 	srv.worker.Enqueue(worker.NewUserJob(client, jobValues))
 

--- a/tonic/routes.go
+++ b/tonic/routes.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/G-Node/tonic/templates"
 	"github.com/G-Node/tonic/tonic/db"
+	"github.com/G-Node/tonic/tonic/form"
 	"github.com/G-Node/tonic/tonic/worker"
 	"github.com/gogs/go-gogs-client"
 	"github.com/gorilla/mux"
@@ -184,6 +185,10 @@ func (srv *Tonic) showJob(w http.ResponseWriter, r *http.Request, sess *db.Sessi
 	for idx := range elements {
 		if val, ok := job.ValueMap[elements[idx].Name]; ok {
 			elements[idx].Value = val
+			// convert <select> elements to regular text <input> to show value
+			if elements[idx].Type == form.Select {
+				elements[idx].Type = form.TextInput
+			}
 		}
 	}
 

--- a/tonic/routes.go
+++ b/tonic/routes.go
@@ -136,8 +136,12 @@ func (srv *Tonic) renderForm(w http.ResponseWriter, r *http.Request, sess *db.Se
 		return
 	}
 
+	userForm, err := srv.worker.PreprocessForm(srv.form, worker.NewClient(srv.config.GINServer, sess.Token))
+	if err != nil {
+		// TODO: Show error to user
+	}
 	data := make(map[string]interface{})
-	data["form"] = srv.form
+	data["form"] = userForm
 
 	if err := tmpl.Execute(w, data); err != nil {
 		srv.log.Printf("Failed to render form: %v", err)

--- a/tonic/service.go
+++ b/tonic/service.go
@@ -130,6 +130,9 @@ func (srv *Tonic) Start() error {
 			return err
 		}
 		srv.log.Print("Logged in and ready")
+	} else {
+		srv.log.Print("No server configured - skipping login and disabling login requirements")
+		srv.log.Print("WARNING: Authentication is open!")
 	}
 	return nil
 }

--- a/tonic/service.go
+++ b/tonic/service.go
@@ -35,7 +35,7 @@ type Tonic struct {
 }
 
 // NewService creates a new Tonic with a given form and custom job action.
-func NewService(webform form.Form, action worker.JobAction, config Config) (*Tonic, error) {
+func NewService(webform form.Form, preAction worker.PreAction, postAction worker.PostAction, config Config) (*Tonic, error) {
 	srv := new(Tonic)
 
 	// Logger
@@ -67,7 +67,8 @@ func NewService(webform form.Form, action worker.JobAction, config Config) (*Ton
 
 	// set form and func
 	srv.SetForm(webform)
-	srv.SetJobAction(action)
+	srv.SetPreAction(preAction)
+	srv.SetPostAction(postAction)
 
 	return srv, nil
 }
@@ -109,10 +110,10 @@ func (srv *Tonic) login() error {
 // Start the service (worker and web server).
 func (srv *Tonic) Start() error {
 	if srv.form == nil || len(srv.form.Pages) == 0 {
-		return fmt.Errorf("nil or empty form is invalid")
+		return fmt.Errorf("No form specified: nil or empty form is invalid")
 	}
-	if srv.worker.Action == nil {
-		return fmt.Errorf("nil job function is invalid")
+	if srv.worker.PostAction == nil && srv.worker.PreAction == nil {
+		return fmt.Errorf("No action specified: Either Pre or Post action should be set.")
 	}
 
 	srv.log.Print("Starting worker")
@@ -171,7 +172,12 @@ func (srv *Tonic) SetForm(webform form.Form) {
 	}
 }
 
-// SetJobAction can be used to set or override the custom job action for the service.
-func (srv *Tonic) SetJobAction(f worker.JobAction) {
-	srv.worker.Action = f
+// SetPreAction can be used to set or override the custom pre-form submission action for the service.
+func (srv *Tonic) SetPreAction(f worker.PreAction) {
+	srv.worker.PreAction = f
+}
+
+// SetPostAction can be used to set or override the custom post-form submission action for the service.
+func (srv *Tonic) SetPostAction(f worker.PostAction) {
+	srv.worker.PostAction = f
 }

--- a/tonic/service.go
+++ b/tonic/service.go
@@ -167,6 +167,12 @@ func (srv *Tonic) SetForm(webform form.Form) {
 	for pageIdx := range webform.Pages {
 		elements := make([]form.Element, len(webform.Pages[pageIdx].Elements))
 		copy(elements, webform.Pages[pageIdx].Elements)
+		// any element without a type will be set to text
+		for idx := range elements {
+			if elements[idx].Type == "" {
+				elements[idx].Type = form.TextInput
+			}
+		}
 		srv.form.Pages[pageIdx].Elements = elements
 		srv.form.Pages[pageIdx].Description = webform.Pages[pageIdx].Description
 	}

--- a/tonic/service.go
+++ b/tonic/service.go
@@ -113,7 +113,7 @@ func (srv *Tonic) Start() error {
 		return fmt.Errorf("No form specified: nil or empty form is invalid")
 	}
 	if srv.worker.PostAction == nil && srv.worker.PreAction == nil {
-		return fmt.Errorf("No action specified: Either Pre or Post action should be set.")
+		return fmt.Errorf("No action specified: Either Pre or Post action should be set")
 	}
 
 	srv.log.Print("Starting worker")

--- a/tonic/service.go
+++ b/tonic/service.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 
 	"github.com/G-Node/tonic/tonic/db"
+	"github.com/G-Node/tonic/tonic/form"
 	"github.com/G-Node/tonic/tonic/web"
 	"github.com/G-Node/tonic/tonic/worker"
 	"github.com/gogs/go-gogs-client"
@@ -29,12 +30,12 @@ type Tonic struct {
 	db     *db.Connection
 	worker *worker.Worker
 	log    *log.Logger
-	form   *Form
+	form   *form.Form
 	config *Config
 }
 
 // NewService creates a new Tonic with a given form and custom job action.
-func NewService(form Form, f worker.JobAction, config Config) (*Tonic, error) {
+func NewService(webform form.Form, action worker.JobAction, config Config) (*Tonic, error) {
 	srv := new(Tonic)
 
 	// Logger
@@ -65,8 +66,8 @@ func NewService(form Form, f worker.JobAction, config Config) (*Tonic, error) {
 	srv.setupWebRoutes()
 
 	// set form and func
-	srv.SetForm(form)
-	srv.SetJobAction(f)
+	srv.SetForm(webform)
+	srv.SetJobAction(action)
 
 	return srv, nil
 }
@@ -156,17 +157,17 @@ func (srv *Tonic) Stop() {
 }
 
 // SetForm can be used to set or override the form for the service.
-func (srv *Tonic) SetForm(form Form) {
-	srv.form = new(Form)
+func (srv *Tonic) SetForm(webform form.Form) {
+	srv.form = new(form.Form)
 	// copy elements manually
-	srv.form.Name = form.Name
-	srv.form.Description = form.Description
-	srv.form.Pages = make([]Page, len(form.Pages))
-	for pageIdx := range form.Pages {
-		elements := make([]Element, len(form.Pages[pageIdx].Elements))
-		copy(elements, form.Pages[pageIdx].Elements)
+	srv.form.Name = webform.Name
+	srv.form.Description = webform.Description
+	srv.form.Pages = make([]form.Page, len(webform.Pages))
+	for pageIdx := range webform.Pages {
+		elements := make([]form.Element, len(webform.Pages[pageIdx].Elements))
+		copy(elements, webform.Pages[pageIdx].Elements)
 		srv.form.Pages[pageIdx].Elements = elements
-		srv.form.Pages[pageIdx].Description = form.Pages[pageIdx].Description
+		srv.form.Pages[pageIdx].Description = webform.Pages[pageIdx].Description
 	}
 }
 

--- a/tonic/tonic_test.go
+++ b/tonic/tonic_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestTonicFailStart(t *testing.T) {
-	if s, _ := NewService(form.Form{}, nil, Config{}); s.Start() == nil {
+	if s, _ := NewService(form.Form{}, nil, nil, Config{}); s.Start() == nil {
 		s.Stop()
 		t.Fatal("Service start succeeded; should have failed")
 	}
@@ -38,7 +38,7 @@ func TestTonicWithForm(t *testing.T) {
 	}
 	f := new(form.Form)
 	f.Pages = []form.Page{{Elements: elems}}
-	srv, err := NewService(*f, noopAction, Config{})
+	srv, err := NewService(*f, nil, noopAction, Config{})
 	if err != nil {
 		t.Fatalf("Failed to initialise tonic service: %s", err.Error())
 	}
@@ -56,7 +56,7 @@ func noopAction(values map[string]string, _, _ *worker.Client) ([]string, error)
 func TestTonicWithAction(t *testing.T) {
 	f := new(form.Form)
 	f.Pages = []form.Page{{Elements: make([]form.Element, 1)}}
-	srv, err := NewService(*f, echoAction, Config{})
+	srv, err := NewService(*f, nil, echoAction, Config{})
 	if err != nil {
 		t.Fatalf("Failed to initialise tonic service: %s", err.Error())
 	}
@@ -111,7 +111,7 @@ func (lb *LogBuffer) String() string {
 func TestLoggers(t *testing.T) {
 	f := new(form.Form)
 	f.Pages = []form.Page{{Elements: make([]form.Element, 1)}}
-	srv, err := NewService(*f, noopAction, Config{})
+	srv, err := NewService(*f, nil, noopAction, Config{})
 	if err != nil {
 		t.Fatalf("Failed to initialise tonic service: %s", err.Error())
 	}

--- a/tonic/tonic_test.go
+++ b/tonic/tonic_test.go
@@ -10,28 +10,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/G-Node/tonic/tonic/form"
 	"github.com/G-Node/tonic/tonic/worker"
 )
 
 func TestTonicFailStart(t *testing.T) {
-	if s, _ := NewService(nil, nil, Config{}); s.Start() == nil {
-		s.Stop()
-		t.Fatal("Service start succeeded; should have failed")
-	}
-
-	if s, _ := NewService(make([]Element, 0), nil, Config{}); s.Start() == nil {
-		s.Stop()
-		t.Fatal("Service start succeeded; should have failed")
-	}
-
-	if s, _ := NewService(make([]Element, 10), nil, Config{}); s.Start() == nil {
+	if s, _ := NewService(form.Form{}, nil, Config{}); s.Start() == nil {
 		s.Stop()
 		t.Fatal("Service start succeeded; should have failed")
 	}
 }
 
 func TestTonicWithForm(t *testing.T) {
-	f := []Element{
+	elems := []form.Element{
 		{
 			ID:          "el1",
 			Name:        "testfield1",
@@ -45,7 +36,9 @@ func TestTonicWithForm(t *testing.T) {
 			Description: "Field of tests, part 2",
 		},
 	}
-	srv, err := NewService(f, noopAction, Config{})
+	f := new(form.Form)
+	f.Pages = []form.Page{{Elements: elems}}
+	srv, err := NewService(*f, noopAction, Config{})
 	if err != nil {
 		t.Fatalf("Failed to initialise tonic service: %s", err.Error())
 	}
@@ -61,7 +54,9 @@ func noopAction(values map[string]string, _, _ *worker.Client) ([]string, error)
 }
 
 func TestTonicWithAction(t *testing.T) {
-	srv, err := NewService(make([]Element, 1), echoAction, Config{})
+	f := new(form.Form)
+	f.Pages = []form.Page{{Elements: make([]form.Element, 1)}}
+	srv, err := NewService(*f, echoAction, Config{})
 	if err != nil {
 		t.Fatalf("Failed to initialise tonic service: %s", err.Error())
 	}
@@ -114,7 +109,9 @@ func (lb *LogBuffer) String() string {
 }
 
 func TestLoggers(t *testing.T) {
-	srv, err := NewService(make([]Element, 1), noopAction, Config{})
+	f := new(form.Form)
+	f.Pages = []form.Page{{Elements: make([]form.Element, 1)}}
+	srv, err := NewService(*f, noopAction, Config{})
 	if err != nil {
 		t.Fatalf("Failed to initialise tonic service: %s", err.Error())
 	}

--- a/tonic/worker/worker.go
+++ b/tonic/worker/worker.go
@@ -119,6 +119,15 @@ func (w *Worker) Enqueue(j *UserJob) {
 	w.queue <- j
 }
 
+func (w *Worker) PreprocessForm(f *form.Form, userClient *Client) (*form.Form, error) {
+	if f == nil {
+		// nothing to do
+		return f, nil
+	}
+	botClient := w.client
+	return w.PreAction(*f, botClient, userClient)
+}
+
 // Stop sends the stop signal to the worker pool and closes the Job channel.
 func (w *Worker) Stop() {
 	// TODO: Finish ongoing jobs?

--- a/tonic/worker/worker.go
+++ b/tonic/worker/worker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/G-Node/tonic/tonic/db"
+	"github.com/G-Node/tonic/tonic/form"
 	"github.com/gogs/go-gogs-client"
 )
 

--- a/tonic/worker/worker.go
+++ b/tonic/worker/worker.go
@@ -120,7 +120,7 @@ func (w *Worker) Enqueue(j *UserJob) {
 }
 
 func (w *Worker) PreprocessForm(f *form.Form, userClient *Client) (*form.Form, error) {
-	if f == nil {
+	if f == nil || w.PreAction == nil {
 		// nothing to do
 		return f, nil
 	}

--- a/tonic/worker/worker.go
+++ b/tonic/worker/worker.go
@@ -142,9 +142,15 @@ func (w *Worker) run(j *UserJob) {
 	j.Lock()
 	defer j.Unlock()
 	defer w.db.UpdateJob(j.Job) // Update job entry in db when done
-	msgs, err := w.PostAction(j.ValueMap, w.client, j.client)
-	j.EndTime = time.Now()
+	var msgs []string
+	var err error
+	if w.PostAction != nil {
+		msgs, err = w.PostAction(j.ValueMap, w.client, j.client)
+	} else {
+		j.Messages = []string{}
+	}
 	j.Messages = msgs
+	j.EndTime = time.Now()
 	if err == nil {
 		w.log.Printf("Job [J%d] %s finished", j.ID, j.Label)
 	} else {

--- a/tonic/worker/worker.go
+++ b/tonic/worker/worker.go
@@ -119,6 +119,7 @@ func (w *Worker) Enqueue(j *UserJob) {
 	w.queue <- j
 }
 
+// PreprocessForm runs the defined PreAction and returns a modified Form.
 func (w *Worker) PreprocessForm(f *form.Form, userClient *Client) (*form.Form, error) {
 	if f == nil || w.PreAction == nil {
 		// nothing to do

--- a/tonic/worker/worker_test.go
+++ b/tonic/worker/worker_test.go
@@ -25,7 +25,7 @@ func TestWorkerEmptyJob(t *testing.T) {
 	defer conn.Close()
 
 	w := New(conn)
-	w.Action = testAction
+	w.PostAction = testAction
 	w.Start()
 	defer w.Stop()
 	j := new(UserJob)
@@ -55,7 +55,7 @@ func TestWorkerAction(t *testing.T) {
 	defer conn.Close()
 
 	w := New(conn)
-	w.Action = testAction
+	w.PostAction = testAction
 	w.Start()
 	defer w.Stop()
 	w.client = NewClient("https://example.org", "testadmintoken")
@@ -87,7 +87,7 @@ func TestWorkerJobFail(t *testing.T) {
 	defer conn.Close()
 
 	w := New(conn)
-	w.Action = testAction
+	w.PostAction = testAction
 	w.Start()
 	defer w.Stop()
 	w.client = NewClient("https://example.org", "testadmintoken")

--- a/utonics/example/main.go
+++ b/utonics/example/main.go
@@ -31,7 +31,7 @@ func main() {
 		Description: "Page 1 of example form",
 		Elements:    elems,
 	}
-	form := form.Form{
+	exampleForm := form.Form{
 		Pages:       []form.Page{page},
 		Name:        "Tonic example form",
 		Description: "",
@@ -44,7 +44,7 @@ func main() {
 		Port:        3000,
 		DBPath:      "./example.db",
 	}
-	ut, err := tonic.NewService(form, nil, exampleFunc, config)
+	ut, err := tonic.NewService(exampleForm, nil, exampleFunc, config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/utonics/example/main.go
+++ b/utonics/example/main.go
@@ -26,6 +26,15 @@ func main() {
 			Description: "Seconds to wait before finishing the job.  Use for simulating long-running jobs.",
 		},
 	}
+	page := tonic.Page{
+		Description: "Page 1 of example form",
+		Elements:    elems,
+	}
+	form := tonic.Form{
+		Pages:       []tonic.Page{page},
+		Name:        "Tonic example form",
+		Description: "",
+	}
 	config := tonic.Config{
 		GINServer:   "", // not used in example
 		GINUsername: "", // not used in example
@@ -34,7 +43,7 @@ func main() {
 		Port:        3000,
 		DBPath:      "./example.db",
 	}
-	ut, err := tonic.NewService(elems, exampleFunc, config)
+	ut, err := tonic.NewService(form, exampleFunc, config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/utonics/example/main.go
+++ b/utonics/example/main.go
@@ -11,8 +11,10 @@ import (
 	"github.com/G-Node/tonic/tonic/worker"
 )
 
+var allElementTypes = []form.ElementType{form.CheckboxInput, form.ColorInput, form.DateInput, form.DateTimeInput, form.EmailInput, form.FileInput, form.HiddenInput, form.MonthInput, form.NumberInput, form.PasswordInput, form.RadioInput, form.RangeInput, form.SearchInput, form.TelInput, form.TextInput, form.TimeInput, form.URLInput, form.WeekInput, form.TextArea, form.Select}
+
 func main() {
-	elems := []form.Element{
+	pageOneElems := []form.Element{
 		{
 			Name:  "name",
 			Label: "Name",
@@ -27,12 +29,35 @@ func main() {
 			Description: "Seconds to wait before finishing the job.  Use for simulating long-running jobs.",
 		},
 	}
-	page := form.Page{
+	examplePage := form.Page{
 		Description: "Page 1 of example form",
-		Elements:    elems,
+		Elements:    pageOneElems,
+	}
+
+	demoElements := make([]form.Element, len(allElementTypes))
+	for idx := range allElementTypes {
+		elemType := allElementTypes[idx]
+		elem := form.Element{
+			ID:          fmt.Sprintf("id%s", elemType),
+			Name:        string(elemType),
+			Label:       fmt.Sprintf("Element type %s", elemType),
+			Description: fmt.Sprintf("An element of type %s", elemType),
+			ValueList: []string{ // will only have effect on the types where it's valid
+				fmt.Sprintf("%s option one", elemType),
+				fmt.Sprintf("%s option two", elemType),
+				fmt.Sprintf("%s option three", elemType),
+			},
+			Type: elemType,
+		}
+		demoElements[idx] = elem
+	}
+
+	elementDemoPage := form.Page{
+		Description: "One of each element supported by Tonic",
+		Elements:    demoElements,
 	}
 	exampleForm := form.Form{
-		Pages:       []form.Page{page},
+		Pages:       []form.Page{examplePage, elementDemoPage},
 		Name:        "Tonic example form",
 		Description: "",
 	}

--- a/utonics/example/main.go
+++ b/utonics/example/main.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/G-Node/tonic/tonic"
+	"github.com/G-Node/tonic/tonic/form"
 	"github.com/G-Node/tonic/tonic/worker"
 )
 
 func main() {
-	elems := []tonic.Element{
+	elems := []form.Element{
 		{
 			Name:  "name",
 			Label: "Name",
@@ -26,12 +27,12 @@ func main() {
 			Description: "Seconds to wait before finishing the job.  Use for simulating long-running jobs.",
 		},
 	}
-	page := tonic.Page{
+	page := form.Page{
 		Description: "Page 1 of example form",
 		Elements:    elems,
 	}
-	form := tonic.Form{
-		Pages:       []tonic.Page{page},
+	form := form.Form{
+		Pages:       []form.Page{page},
 		Name:        "Tonic example form",
 		Description: "",
 	}

--- a/utonics/example/main.go
+++ b/utonics/example/main.go
@@ -44,7 +44,7 @@ func main() {
 		Port:        3000,
 		DBPath:      "./example.db",
 	}
-	ut, err := tonic.NewService(form, exampleFunc, config)
+	ut, err := tonic.NewService(form, nil, exampleFunc, config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -41,7 +41,7 @@ func main() {
 		Elements:    elems,
 	}
 	page2 := form.Page{
-		Description: "Extra repository submodules.  Each of the following elements creates an extra submodule which can be managed independently.  It has its own access permissions, public visibility, and can be published separatrely.  It is linked at the top level of the main repository.",
+		Description: "Extra repository submodules.  Each of the following elements creates an extra submodule which can be managed independently.  It has its own access permissions, public visibility, and can be published separately.  It is linked at the top level of the main repository.",
 		Elements: []form.Element{
 			{
 				ID:          "rawdata",
@@ -66,7 +66,7 @@ func main() {
 		Port:        3000,
 		DBPath:      "./labproject.db",
 	}
-	tsrv, err := tonic.NewService(form, nil, newProject, config)
+	tsrv, err := tonic.NewService(form, setForm, newProject, config)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -74,6 +74,20 @@ func main() {
 	tsrv.WaitForInterrupt()
 	tsrv.Stop()
 
+}
+
+func setForm(f form.Form, botClient, userClient *worker.Client) (*form.Form, error) {
+	orgs, err := getAvailableOrgs(botClient, userClient)
+	if err != nil {
+		return &f, err
+	}
+
+	if len(orgs) == 1 {
+		// Only one org is available so set it in the form
+		f.Pages[0].Elements[0].Value = orgs[0].UserName
+	}
+
+	return &f, nil
 }
 
 func newProject(values map[string]string, botClient, userClient *worker.Client) ([]string, error) {

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -3,16 +3,18 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/G-Node/tonic/tonic"
-	"github.com/G-Node/tonic/tonic/worker"
-	"github.com/gogs/go-gogs-client"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/G-Node/tonic/tonic"
+	"github.com/G-Node/tonic/tonic/form"
+	"github.com/G-Node/tonic/tonic/worker"
+	"github.com/gogs/go-gogs-client"
 )
 
 func main() {
-	elems := []tonic.Element{
+	elems := []form.Element{
 		{
 			ID:       "laborg",
 			Label:    "Lab organisation",
@@ -34,13 +36,13 @@ func main() {
 			Required:    false,
 		},
 	}
-	page1 := tonic.Page{
+	page1 := form.Page{
 		Description: "Creating a new project will create a new set of repositories based on the lab template and a team for granting access to all project members.",
 		Elements:    elems,
 	}
-	page2 := tonic.Page{
+	page2 := form.Page{
 		Description: "Extra repository submodules.  Each of the following elements creates an extra submodule which can be managed independently.  It has its own access permissions, public visibility, and can be published separatrely.  It is linked at the top level of the main repository.",
-		Elements: []tonic.Element{
+		Elements: []form.Element{
 			{
 				ID:          "rawdata",
 				Label:       "Raw data submodule",
@@ -50,8 +52,8 @@ func main() {
 			},
 		},
 	}
-	form := tonic.Form{
-		Pages:       []tonic.Page{page1, page2},
+	form := form.Form{
+		Pages:       []form.Page{page1, page2},
 		Name:        "Project creation",
 		Description: "",
 	}

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -33,6 +33,7 @@ func main() {
 			Label:       "Description",
 			Name:        "description",
 			Description: "Long project description",
+			Type:        form.TextArea,
 			Required:    false,
 		},
 	}

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	form := []tonic.Element{
+	elems := []tonic.Element{
 		{
 			ID:       "laborg",
 			Label:    "Lab organisation",
@@ -33,6 +33,15 @@ func main() {
 			Description: "Long project description",
 			Required:    false,
 		},
+	}
+	page := tonic.Page{
+		Description: "Creating a new project will create a new set of repositories based on the lab template and a team for granting access to all project members.",
+		Elements:    elems,
+	}
+	form := tonic.Form{
+		Pages:       []tonic.Page{page},
+		Name:        "Project creation",
+		Description: "",
 	}
 	username, password := readPassfile("testbot")
 	config := tonic.Config{

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -19,6 +19,7 @@ func main() {
 			ID:       "laborg",
 			Label:    "Lab organisation",
 			Name:     "organisation",
+			Type:     form.Select,
 			Required: true,
 		},
 		{

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -84,12 +84,12 @@ func setForm(f form.Form, botClient, userClient *worker.Client) (*form.Form, err
 		return &f, err
 	}
 
-	if len(orgs) == 1 {
-		// Only one org is available so set it in the form and set readonly
-		orgelem := &f.Pages[0].Elements[0]
-		orgelem.Value = orgs[0].UserName
-		orgelem.ReadOnly = true
-		orgelem.Description = fmt.Sprintf("%q is the only organisation with %q functionality enabled", orgelem.Value, f.Name)
+	orgelem := &f.Pages[0].Elements[0]
+	// Add available org names to ValueList for field
+	valueList := make([]string, len(orgs))
+	for idx, availOrg := range orgs {
+		valueList[idx] = availOrg.UserName
+		orgelem.ValueList = valueList
 	}
 
 	return &f, nil

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -66,7 +66,7 @@ func main() {
 		Port:        3000,
 		DBPath:      "./labproject.db",
 	}
-	tsrv, err := tonic.NewService(form, newProject, config)
+	tsrv, err := tonic.NewService(form, nil, newProject, config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -83,8 +83,11 @@ func setForm(f form.Form, botClient, userClient *worker.Client) (*form.Form, err
 	}
 
 	if len(orgs) == 1 {
-		// Only one org is available so set it in the form
-		f.Pages[0].Elements[0].Value = orgs[0].UserName
+		// Only one org is available so set it in the form and set readonly
+		orgelem := &f.Pages[0].Elements[0]
+		orgelem.Value = orgs[0].UserName
+		orgelem.ReadOnly = true
+		orgelem.Description = fmt.Sprintf("%q is the only organisation with %q functionality enabled", orgelem.Value, f.Name)
 	}
 
 	return &f, nil

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -34,12 +34,24 @@ func main() {
 			Required:    false,
 		},
 	}
-	page := tonic.Page{
+	page1 := tonic.Page{
 		Description: "Creating a new project will create a new set of repositories based on the lab template and a team for granting access to all project members.",
 		Elements:    elems,
 	}
+	page2 := tonic.Page{
+		Description: "Extra repository submodules.  Each of the following elements creates an extra submodule which can be managed independently.  It has its own access permissions, public visibility, and can be published separatrely.  It is linked at the top level of the main repository.",
+		Elements: []tonic.Element{
+			{
+				ID:          "rawdata",
+				Label:       "Raw data submodule",
+				Name:        "rawdata",
+				Description: "Add a raw data submodule",
+				Required:    false,
+			},
+		},
+	}
 	form := tonic.Form{
-		Pages:       []tonic.Page{page},
+		Pages:       []tonic.Page{page1, page2},
 		Name:        "Project creation",
 		Description: "",
 	}


### PR DESCRIPTION
- Support Pre and Post Actions.  Pre actions can be used to set restrictions on forms such as values or enabling/disabling fields.  A PreAction can essentially redefine an entire form.
- Forms can now have multiple pages and support most input element types.
- Added documentation that describes the two built-in services.  This can serve as a guide for how to write more services.