### PR TITLE
Update docs for labproject setup

### DIFF
--- a/docs/labproject.md
+++ b/docs/labproject.md
@@ -1,21 +1,35 @@
 # Lab project service
 
-The [lab project](/utonics/labproject/main.go) service takes advantage of almost all the features of Tonic.  Its purpose is to create repositories inside an organisation on GIN where the user is not an administrator or owner.
-It defines the following service components:
+The [lab project](/utonics/labproject/main.go) service takes advantage of almost all the features of Tonic.
+The purpose of the service is to assist members of a Research Lab (represented by an Organisation on GIN) with using the GIN services in a way that promotes reproducible research practices.
 
-## Form
+> Note: The following list contains planned features that are not yet implemented.
 
-The Form consists of two pages.
+The service defines a set of forms that can perform administrative actions on behalf of users such as:
+- [x] Creating a repository structure with submodules based on a pre-defined research project template.
+- [x] Creating teams to group users and repositories and to control access permissions.
+- [ ] Modifying existing repositories and teams during the project lifetime.
 
-The first page consists of three elements:
+## Setup and configuration
+
+The configuration specifies the GIN server to connect to (currently gin.dev.g-node.org for testing purposes).  The username and password are for the bot user that the service uses to perform actions.  These credentials should be provided through a json file called `testbot`.
+
+## Internals and components
+
+Internally the service performs actions as an administrator of the organisation and sometimes the whole GIN instance (site admin).
+This is represented by a `worker.Client`, which is responsible for making requests to the GIN API and performing git operations for the creation of repositories.
+
+The service defines the following components:
+
+### Form
+
+The form consists of three elements:
 1. Lab organisation: The name of the organisation in which the repository is going to be created.
 2. Project name: The name of the repository or repositories to be created.
 3. Optionally a team name where the repository will be added. If none is indicated, a team with the same name as the repository will be created.
 4. Description: A long description for the project.
 
-The second page includes toggles for submodules that the user may or may not require for the project.
-
-## PreAction
+### PreAction
 
 The PreAction determines whether there are any organisations on GIN in which the user is allowed to create repositories.  The requirements for an organisation to be eligible are:
 - The service bot must be an owner or administrator of the organisation.
@@ -23,18 +37,18 @@ The PreAction determines whether there are any organisations on GIN in which the
 
 Since multiple organisations may fit the requirements, the PreAction determines their names and sets the available values for the _Lab organisation_ select field.
 
-## PostAction
+### PostAction
 
 The PostAction receives the form values and creates the repository on behalf of the user.  Before doing so, it checks if the organisation is in fact eligible using the same criteria defined in the [PreAction](#preaction).
 
 If the input is valid, the service performs the following actions:
-- Create a **repository** with the _Project name_ as defined by the user.
-- Create a **team** with the _Project name_ as defined by the user.
-- Adds the service user to the **team**.
-- Adds the **repository** to the **team**.
-
-*Note: More actions are planned for this service and will be added soon.*
-
-## Config
-
-The configuration specifies the GIN server to connect to (currently gin.dev.g-node.org for testing purposes).  The username and password are for the bot user that the service uses to perform actions.  These credentials should be provided through a json file called `testbot`.
+- Clone the **template repository** (specified in the main service configuration) and all its submodules.
+- Create a **repository** with the _Project name_ as defined by the user in the _Organisation_ on the server.
+  - Create one repository for each **submodule** found in the template with the name _Project name_._submodule name_ in the _Organisation_ on the server.
+- Configure the **repository** with a new remote pointing to the newly created repository on the server.
+  - Configure each **submodule** with a new remote pointing to the newly created submodule repositories on the server.
+- Push the **repository contents** to the server.
+  - Push each **submodule's contents** to the server.
+- Create a **team** with the _Team name_ provided by the user (or _Project name_ if unspecified).
+- Adds the logged in user to the **team**.
+- Adds the **repository** and its **submodules** to the **team**.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ The example service is simply for demonstration purposes. See the [Example servi
 
 ### Compile and run
 
-Requires Go v1.15.
+Requires Go v1.15 or newer.
 
 Clone this repository, build the included services, and run:
 ```
@@ -148,7 +148,7 @@ touch /path/to/labproject.db
 
 To start the service run:
 ```
-docker run -it --rm --volume /path/to/labproject.db:/tonic/labproject.db --volume /path/to/labproject.json:/tonic/labproject.json --name labproject local/tonic:labproject
+docker run -it --rm --publish 3000:3000 --volume /path/to/labproject.db:/tonic/labproject.db --volume /path/to/labproject.json:/tonic/labproject.json --name labproject local/tonic:labproject
 ```
 
 *NOTE:* The `--rm` flag will delete the container once it exits.
@@ -156,7 +156,7 @@ docker run -it --rm --volume /path/to/labproject.db:/tonic/labproject.db --volum
 The `--volume /path/to/labproject.json:/tonic/labproject.json` option places the configuration file (see [Configuration](#configuration) above) into the running container for the service to read. The path must be changed to a file on disk with the configuration values.
 The `--volume /path/to/labproject.db:/tonic/labproject.db` option places the database file (see [Configuration](#configuration) above) into the running container for the service to read. It is important that the file already exists outside the container, otherwise it will be created as a directory on service startup and the service will fail with an error.
 
-The `-p 3000:3000` option publishes port 3000 from inside the container to the host system's network (even externally). It makes the running container accessible at http://localhost:3000. If omitted, the container can be accessed from the container's internal IP address, which can be determined using `docker inspect`.
+The `--publish 3000:3000` option publishes port 3000 from inside the container to the host system's network (even externally). It makes the running container accessible at http://localhost:3000. If omitted, the container can be accessed from the container's internal IP address, which can be determined using `docker inspect labproject`.
 
 The output should be similar to the following:
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ The example service is simply for demonstration purposes. See the [Example servi
 
 Requires Go v1.15.
 
-Clone this repository, build the examples, and run:
+Clone this repository, build the included services, and run:
 ```
 git clone https://github.com/G-Node/tonic
 cd tonic
@@ -72,42 +72,35 @@ Type `ctrl+c` to stop the service.
 
 ## Lab project service
 
-The Lab project service requires a configuration and credentials to make calls against a GIN API. See the [Lab project service](./labproject.md) document for a detailed description.
+The Lab project service requires a configuration and credentials to make calls against a GIN API and clone repositories. See the [Lab project service](./labproject.md) document for a detailed description.
 
 ### Configuration
 
-TODO: Update this doc
-
-The configuration is currently hard-coded and looks like this:
-```go
-username, password := readPassfile("testbot")
-config := tonic.Config{
-    GINServer:   "https://gin.dev.g-node.org",
-    GINUsername: username,
-    GINPassword: password,
-    CookieName:  "utonic-labproject",
-    Port:        3000,
-    DBPath:      "./labproject.db",
-}
-```
-
-You may notice it reads credentials from a file called `testbot`. This file should have a username and password in JSON format and be in the working directory.
-
-`./testbot:`
-```
+The configuration is read from a file called `labproject.json` in the working directory where the service is launched.
+The following configuration keys are supported:
+```json
 {
-    "username": "testbot",
-    "password": "very secret password"
+  "gin": {
+    "web": "<web address for GIN service: required>",
+      "git": "<git address for GIN service: required>",
+      "username": "<service username: required>",
+      "password": "<service pasword: required>"
+  },
+  "templaterepo": "<template repository: required>",
+  "cookiename": "<session cookie name: optional (default: utonic-labproject)>",
+  "port": "<port for service to listen on: optional (default: 3000)>",
+  "dbpath": "<path to sqlite database file: optional (default: ./labproject.db)>"
 }
 ```
 
-The credentials can be the username and password for any user on the GIN DEV server (gin.dev.g-node.org).
+If any configuration values marked `required` are not specified, the service will fail to start.
+Omitting optional values will set and print the default value on startup.
 
 ### Compile and run
 
 Requires Go v1.15.
 
-Clone this repository, build the examples, and run:
+Clone this repository, build the included services, and run:
 ```
 git clone https://github.com/G-Node/tonic
 cd tonic
@@ -148,29 +141,35 @@ The `--build-arg service=labproject` option specifies which service to build. If
 
 *NOTE:* Here the image is named `local/tonic` and tagged as `labproject`, but this could be named anything.
 
-For the example, no options or external files are required to run:
+For the first run, an empty file must be created for the database that will be mapped into the container:
 ```
-docker run --rm -p 3000:3000 --volume /path/to/credentials:/tonic/testbot local/tonic:labproject
+touch /path/to/labproject.db
+```
+
+To start the service run:
+```
+docker run -it --rm --volume /path/to/labproject.db:/tonic/labproject.db --volume /path/to/labproject.json:/tonic/labproject.json --name labproject local/tonic:labproject
 ```
 
 *NOTE:* The `--rm` flag will delete the container once it exits.
 
-The `--volume /path/to/credentials:/tonic/testbot` option places the credentials file (see [Configuration](#configuration) above) into the running container for the service to read. The path must be changed to a file on disk with the correct username and password.
+The `--volume /path/to/labproject.json:/tonic/labproject.json` option places the configuration file (see [Configuration](#configuration) above) into the running container for the service to read. The path must be changed to a file on disk with the configuration values.
+The `--volume /path/to/labproject.db:/tonic/labproject.db` option places the database file (see [Configuration](#configuration) above) into the running container for the service to read. It is important that the file already exists outside the container, otherwise it will be created as a directory on service startup and the service will fail with an error.
 
 The `-p 3000:3000` option publishes port 3000 from inside the container to the host system's network (even externally). It makes the running container accessible at http://localhost:3000. If omitted, the container can be accessed from the container's internal IP address, which can be determined using `docker inspect`.
 
 The output should be similar to the following:
 ```
-tonic: 2020/10/02 13:31:06 Initialising database
-tonic: 2020/10/02 13:31:06 Initialising worker
-tonic: 2020/10/02 13:31:06 Initialising web service
-tonic: 2020/10/02 13:31:06 Setting up router
-tonic: 2020/10/02 13:31:06 Starting worker
-tonic: 2020/10/02 13:31:06 Worker started
-tonic: 2020/10/02 13:31:06 Starting web service
-tonic: 2020/10/02 13:31:06 Web server started
-tonic: 2020/10/02 13:31:06 No server configured - skipping login and disabling login requirements
-tonic: 2020/10/02 13:31:06 WARNING: Authentication is open!
+tonic: 2020/11/23 12:43:21 Initialising database
+tonic: 2020/11/23 12:43:21 Initialising worker
+tonic: 2020/11/23 12:43:21 Initialising web service
+tonic: 2020/11/23 12:43:21 Setting up router
+tonic: 2020/11/23 12:43:21 Starting worker
+tonic: 2020/11/23 12:43:21 Worker started
+tonic: 2020/11/23 12:43:21 Starting web service
+tonic: 2020/11/23 12:43:21 Web server started
+tonic: 2020/11/23 12:43:21 Logging in to gin (<gin web address>)
+tonic: 2020/11/23 12:43:21 Logged in and ready
 ```
 
 Type `ctrl+c` to stop the service.

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -67,22 +67,8 @@ func main() {
 		Description: "Creating a new project will create a new set of repositories based on the lab template and a team for granting access to all project members.",
 		Elements:    elems,
 	}
-	page2 := form.Page{
-		Description: "Extra repository submodules.  Each of the following elements creates an extra submodule which can be managed independently.  It has its own access permissions, public visibility, and can be published separately.  It appears as a subdirectory at the top level of the main repository.",
-		Elements: []form.Element{
-			{
-				ID:          "submodules",
-				Label:       "Submodules",
-				Name:        "submodules",
-				Description: "",
-				Required:    false,
-				Type:        form.CheckboxInput,
-				ValueList:   []string{"Raw", "Public", "Figures"},
-			},
-		},
-	}
 	lpform := form.Form{
-		Pages:       []form.Page{page1, page2},
+		Pages:       []form.Page{page1},
 		Name:        "Project creation",
 		Description: "",
 	}

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -55,10 +55,10 @@ func main() {
 			Type:        form.TextInput,
 		},
 		{
-			ID:          "description",
-			Label:       "Description",
-			Name:        "description",
-			Description: "Long project description",
+			ID:          "title",
+			Label:       "Title",
+			Name:        "title",
+			Description: "Project title",
 			Type:        form.TextArea,
 			Required:    false,
 		},
@@ -110,10 +110,10 @@ func setForm(f form.Form, botClient, userClient *worker.Client) (*form.Form, err
 func newProject(values map[string][]string, botClient, userClient *worker.Client) ([]string, error) {
 	orgName := values["organisation"][0] // required
 	project := values["project"][0]      // required
-	description := ""
+	title := ""
 	teamName := ""
-	if len(values["description"]) > 0 {
-		description = values["description"][0]
+	if len(values["title"]) > 0 {
+		title = values["title"][0]
 	}
 	if len(values["team"]) > 0 {
 		teamName = values["team"][0]
@@ -184,7 +184,7 @@ func newProject(values map[string][]string, botClient, userClient *worker.Client
 	createAndSetRemote := func(name string) error {
 		repoOpt := gogs.CreateRepoOption{
 			Name:        name,
-			Description: description,
+			Description: title,
 			Private:     true,
 			AutoInit:    false,
 			Readme:      "Default",
@@ -295,7 +295,7 @@ func newProject(values map[string][]string, botClient, userClient *worker.Client
 		// Create Team
 		// TODO: Use non admin command when it becomes available
 		msgs = append(msgs, fmt.Sprintf("Creating team %s/%s", orgName, project))
-		team, err = botClient.AdminCreateTeam(orgName, gogs.CreateTeamOption{Name: teamName, Description: description, Permission: "write"})
+		team, err = botClient.AdminCreateTeam(orgName, gogs.CreateTeamOption{Name: teamName, Description: title, Permission: "write"})
 		if err != nil {
 			msgs = append(msgs, fmt.Sprintf("Failed to create team: %s", err.Error()))
 			return msgs, err


### PR DESCRIPTION
- Extended configuration description and setup instructions for labproject service. Repeats the same info from quickstart but with more detailed explanations and setup of the user on GIN. Closes #28.
- Some minor corrections in quickstart guide.
- Removed second page from labproject form: It is no longer needed; the service clones the template repository with all its submodules as of PR #27.
- Renamed the "Description" field in the labproject form to "Title". This reflects a change we made on GIN where we renamed the repository description field to Title to encourage users to use it as the title of their datasets or projects.