### PR TITLE
Add user ID to session table and test routing

### DIFF
--- a/tonic/db/db_test.go
+++ b/tonic/db/db_test.go
@@ -77,7 +77,7 @@ func TestSessionStore(t *testing.T) {
 		t.Fatalf("Failed to delete empty session: %s", err.Error())
 	}
 
-	sess := NewSession("faketoken")
+	sess := NewSession("faketoken", 12)
 	if db.InsertSession(sess) != nil {
 		t.Fatalf("Failed inserting new session: %s", err.Error())
 	}
@@ -86,7 +86,7 @@ func TestSessionStore(t *testing.T) {
 		t.Fatal("Succeeded inserting duplicate session")
 	}
 
-	dupe := NewSession("anothertoken")
+	dupe := NewSession("anothertoken", 19)
 	dupe.ID = sess.ID
 	if db.InsertSession(dupe) == nil {
 		t.Fatal("Succeeded inserting session with conflicting ID")

--- a/tonic/db/session.go
+++ b/tonic/db/session.go
@@ -13,17 +13,20 @@ type Session struct {
 	ID string `xorm:"pk"`
 	// App Token for user
 	Token string
+	// ID of the user who owns the session (maps to GIN user ID)
+	UserID int64
 	// Time when the session was created (for expiration)
 	Created time.Time
 }
 
 // NewSession creates a new session for a user with the given token and a new
 // unique ID.
-func NewSession(token string) *Session {
+func NewSession(token string, userID int64) *Session {
 	sess := new(Session)
 	sess.ID = uuid.New().String()
 	sess.Token = token
 	sess.Created = time.Now()
+	sess.UserID = userID
 	return sess
 }
 

--- a/tonic/routes.go
+++ b/tonic/routes.go
@@ -91,6 +91,7 @@ func (srv *Tonic) userLoginPost(w http.ResponseWriter, r *http.Request) {
 	// If no GIN.Web server is defined, set the token as the username +
 	// password and let them through with any password.
 	var userToken string
+	var userID int64
 	if srv.config.GIN.Web != "" {
 		client := gogs.NewClient(srv.config.GIN.Web, "")
 		tokens, err := client.ListAccessTokens(username, password)
@@ -110,11 +111,19 @@ func (srv *Tonic) userLoginPost(w http.ResponseWriter, r *http.Request) {
 		} else {
 			userToken = tokens[0].Sha1
 		}
+		client = gogs.NewClient(srv.config.GIN.Web, userToken)
+		user, err := client.GetSelfInfo()
+		if err != nil {
+			srv.web.ErrorResponse(w, http.StatusInternalServerError, "login succeeded but failed to retrieve user data")
+			return
+		}
+		userID = user.ID
 	} else {
 		userToken = username + password
+		userID = -1
 	}
 
-	sess := db.NewSession(userToken)
+	sess := db.NewSession(userToken, userID)
 
 	cookie := http.Cookie{
 		Name:    srv.config.CookieName,
@@ -235,15 +244,7 @@ func (srv *Tonic) renderLog(w http.ResponseWriter, r *http.Request, sess *db.Ses
 		return
 	}
 
-	cl := worker.NewClient(srv.config.GIN.Web, srv.config.GIN.Git, sess.Token)
-	user, err := cl.GetSelfInfo()
-	if err != nil {
-		// TODO: Check for error type (unauthorized?)
-		srv.web.ErrorResponse(w, http.StatusInternalServerError, "Error reading jobs from DB")
-		return
-	}
-
-	joblog, err := srv.db.GetUserJobs(user.ID)
+	joblog, err := srv.db.GetUserJobs(sess.UserID)
 	if err != nil {
 		srv.web.ErrorResponse(w, http.StatusInternalServerError, "Error reading jobs from DB")
 		return

--- a/tonic/routes.go
+++ b/tonic/routes.go
@@ -184,6 +184,11 @@ func (srv *Tonic) showJob(w http.ResponseWriter, r *http.Request, sess *db.Sessi
 		return
 	}
 
+	if job.UserID != sess.UserID {
+		srv.web.ErrorResponse(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
 	tmpl := template.New("layout")
 	tmpl, err = tmpl.Parse(templates.Layout)
 	if err != nil {

--- a/tonic/routes_test.go
+++ b/tonic/routes_test.go
@@ -1,0 +1,98 @@
+package tonic
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/G-Node/tonic/tonic/db"
+	"github.com/G-Node/tonic/tonic/form"
+)
+
+func TestLoginRedirect(t *testing.T) {
+	f := new(form.Form)
+	f.Pages = []form.Page{{Elements: make([]form.Element, 1)}}
+	srv, err := NewService(*f, nil, echoAction, Config{CookieName: "test-cookie"})
+	if err != nil {
+		t.Fatalf("failed to initialise tonic service: %s", err.Error())
+	}
+	handler := srv.web.Handler
+
+	checkStatusNoCookie := func(method, route string) {
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest(method, route, nil)
+		if err != nil {
+			t.Errorf("failed to create request: %s %s", method, route)
+		}
+		handler.ServeHTTP(rr, req)
+		if status := rr.Code; status != http.StatusFound {
+			t.Errorf("handler returned wrong status code: got %v expected %v", status, http.StatusFound)
+		}
+	}
+
+	checkStatusNoCookie("GET", "/")
+	checkStatusNoCookie("POST", "/")
+	checkStatusNoCookie("GET", "/log")
+	checkStatusNoCookie("GET", "/log/42")
+	checkStatusNoCookie("GET", "/log/1337")
+
+	checkStatusBadCookie := func(method, route string) {
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest(method, route, nil)
+		if err != nil {
+			t.Errorf("failed to create request: %s %s", method, route)
+		}
+		req.Header.Add("Cookie", "test-cookie=bad")
+		handler.ServeHTTP(rr, req)
+		if status := rr.Code; status != http.StatusFound {
+			t.Errorf("handler returned wrong status code: got %v expected %v", status, http.StatusFound)
+		}
+	}
+
+	checkStatusBadCookie("GET", "/")
+	checkStatusBadCookie("POST", "/")
+	checkStatusBadCookie("GET", "/log")
+	checkStatusBadCookie("GET", "/log/42")
+	checkStatusBadCookie("GET", "/log/1337")
+}
+
+func TestFormRoutes(t *testing.T) {
+	f := new(form.Form)
+	f.Pages = []form.Page{{Elements: make([]form.Element, 1)}}
+	srv, err := NewService(*f, nil, echoAction, Config{CookieName: "test-cookie"})
+	if err != nil {
+		t.Fatalf("failed to initialise tonic service: %s", err.Error())
+	}
+	handler := srv.web.Handler
+
+	// Add test cookie to the database
+	testSession := db.NewSession("test-token")
+	srv.db.InsertSession(testSession)
+
+	cookie := testSession.ID
+
+	// Load the form
+	getReq, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Error("failed to create request: GET /")
+	}
+	getReq.Header.Add("Cookie", fmt.Sprintf("test-cookie=%s", cookie))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, getReq)
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v expected %v", status, http.StatusOK)
+	}
+
+	// Send empty data to the form
+	rr = httptest.NewRecorder()
+	postReq, err := http.NewRequest("POST", "/", nil)
+	if err != nil {
+		t.Error("failed to create request: POST /")
+	}
+	postReq.Header.Add("Cookie", fmt.Sprintf("test-cookie=%s", cookie))
+	handler.ServeHTTP(rr, postReq)
+	if status := rr.Code; status != http.StatusSeeOther {
+		t.Errorf("handler returned wrong status code: got %v expected %v", status, http.StatusSeeOther)
+	}
+}

--- a/tonic/routes_test.go
+++ b/tonic/routes_test.go
@@ -1,7 +1,9 @@
 package tonic
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -95,4 +97,54 @@ func TestFormRoutes(t *testing.T) {
 	if status := rr.Code; status != http.StatusSeeOther {
 		t.Errorf("handler returned wrong status code: got %v expected %v", status, http.StatusSeeOther)
 	}
+}
+
+func TestLogRoutes(t *testing.T) {
+	f := new(form.Form)
+	f.Pages = []form.Page{{Elements: make([]form.Element, 1)}}
+	srv, err := NewService(*f, nil, echoAction, Config{CookieName: "test-cookie"})
+	if err != nil {
+		t.Fatalf("failed to initialise tonic service: %s", err.Error())
+	}
+	handler := srv.web.Handler
+
+	// Add test cookie to the database
+	testSession := db.NewSession("test-token", 42)
+	srv.db.InsertSession(testSession)
+
+	cookie := testSession.ID
+
+	jobLabel := "TestJob"
+
+	checkLogJobCount := func(route string, nexpected int) {
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", route, nil)
+		if err != nil {
+			t.Errorf("failed to create request: %s", route)
+		}
+		req.Header.Add("Cookie", fmt.Sprintf("test-cookie=%s", cookie))
+		handler.ServeHTTP(rr, req)
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v expected %v", status, http.StatusOK)
+		}
+
+		content, err := ioutil.ReadAll(rr.Body)
+		if err != nil {
+			t.Errorf("failed to read response body: %s", err.Error())
+		}
+		if njobs := bytes.Count(content, []byte(jobLabel)); njobs != nexpected {
+			t.Errorf("Job log returned %d, expected %d", njobs, nexpected)
+		}
+	}
+
+	checkLogJobCount("/log", 0)
+
+	srv.db.InsertJob(&db.Job{ID: 12, UserID: 42, Label: jobLabel})
+	checkLogJobCount("/log", 1)
+
+	srv.db.InsertJob(&db.Job{ID: 16, UserID: 42, Label: jobLabel})
+	checkLogJobCount("/log", 2)
+
+	srv.db.InsertJob(&db.Job{ID: 26, UserID: 44, Label: jobLabel}) // other user
+	checkLogJobCount("/log", 2)
 }

--- a/tonic/routes_test.go
+++ b/tonic/routes_test.go
@@ -67,7 +67,7 @@ func TestFormRoutes(t *testing.T) {
 	handler := srv.web.Handler
 
 	// Add test cookie to the database
-	testSession := db.NewSession("test-token")
+	testSession := db.NewSession("test-token", 198)
 	srv.db.InsertSession(testSession)
 
 	cookie := testSession.ID


### PR DESCRIPTION
Each session in the database now stores the user ID that owns it.  This saves us from needing to contact the GIN service every time a job or the job log needs to be retrieved.

Fixed a bug where users could view jobs they don't own.

Added tests for routing:
- Login redirect
- Form GET and POST routing
- Job log item count
- Individual job retrieval