### PR TITLE
utonics/labproject: use relative URLs in .gitmodules

### DIFF
--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -411,7 +411,7 @@ func getAvailableOrgsAndTeams(botClient, userClient *worker.Client) (map[string]
 }
 
 func readConfig(filename string) *labProjectConfig {
-	confFile, err := dOpen(filename)
+	confFile, err := os.Open(filename)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -244,7 +244,8 @@ func newProject(values map[string][]string, botClient, userClient *worker.Client
 	}
 	submoduleForEach("git", "checkout", "master") // TODO: find default branch instead
 	submoduleForEach("git", "pull")
-
+	submoduleForEach("gin", "init")
+	
 	submodules, err := parseGitModules(".")
 	if err != nil {
 		msgs = append(msgs, fmt.Sprintf("Failed to parse .gitmodules: %v", err.Error()))
@@ -295,7 +296,7 @@ func newProject(values map[string][]string, botClient, userClient *worker.Client
 			msgs = append(msgs, fmt.Sprintf("Upload failed: %s", err.Error()))
 			return msgs, err
 		}
-		os.Chdir("..")
+		os.Chdir(localRepoPath)
 	}
 
 	orgTeams, err := botClient.ListTeams(orgName)
@@ -347,7 +348,7 @@ func newProject(values map[string][]string, botClient, userClient *worker.Client
 		return msgs, err
 	}
 	for smName := range submodules {
-		repoName := project + "." + smName
+		repoName := project + "." + strings.ReplaceAll(smName, "/", "_")
 		if err := botClient.AdminAddTeamRepository(team.ID, repoName); err != nil {
 			msgs = append(msgs, fmt.Sprintf("Failed to add repository %q to team: %s", repoName, err.Error()))
 			return msgs, err
@@ -410,7 +411,7 @@ func getAvailableOrgsAndTeams(botClient, userClient *worker.Client) (map[string]
 }
 
 func readConfig(filename string) *labProjectConfig {
-	confFile, err := os.Open(filename)
+	confFile, err := dOpen(filename)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/utonics/labproject/main.go
+++ b/utonics/labproject/main.go
@@ -444,6 +444,8 @@ func readConfig(filename string) *labProjectConfig {
 }
 
 func uploadProjectRepository(botClient *worker.Client, remote string) error {
+	// Set local git config
+	git.SetGitUser(botClient.GIN.Username, botClient.GIN.Username+"@tonic")
 	uploadchan := make(chan git.RepoFileStatus)
 	go botClient.GIN.Upload([]string{}, []string{remote}, uploadchan)
 	for stat := range uploadchan {


### PR DESCRIPTION
 Create relative URLs for the new submodules and write them back to the `.gitmodules` file.  This makes working with submodules much more flexible since it works for both git and http remotes, depending on how the parent repository is cloned. It also gets around any issues with linking in the GIN web interface.

@jcolomb please test it and let me know how it works for you.